### PR TITLE
Adjusted region enum order and extent

### DIFF
--- a/src/gov/usgs/earthquake/nshm/www/services/meta/Region.java
+++ b/src/gov/usgs/earthquake/nshm/www/services/meta/Region.java
@@ -19,17 +19,9 @@ public enum Region implements Constrained {
 	CEUS(
 			"Central & Eastern US",
 			new double[] {24.6, 50.0},
-			new double[] {-125.0, -65.0},
-			new RegionConstraints(
-				EnumSet.of(VS_2000, VS_760),
-				EnumSet.of(PGA, SA0P2, SA1P0))),
-
-	COUS(
-			"Conterminous US",
-			new double[] {24.6, 50.0},
 			new double[] {-115.0, -65.0},
 			new RegionConstraints(
-				EnumSet.of(VS_760),
+				EnumSet.of(VS_2000, VS_760),
 				EnumSet.of(PGA, SA0P2, SA1P0))),
 
 	WUS(
@@ -38,6 +30,14 @@ public enum Region implements Constrained {
 			new double[] {-125.0, -100.0},
 			new RegionConstraints(
 				EnumSet.of(VS_1150, VS_760, VS_537, VS_360, VS_259, VS_180),
+				EnumSet.of(PGA, SA0P2, SA1P0))),
+
+	COUS(
+			"Conterminous US",
+			new double[] {24.6, 50.0},
+			new double[] {-125.0, -65.0},
+			new RegionConstraints(
+				EnumSet.of(VS_760),
 				EnumSet.of(PGA, SA0P2, SA1P0)));
 
 	final String label;
@@ -48,10 +48,10 @@ public enum Region implements Constrained {
 	final Constraints constraints;
 
 	private Region(
-			String label, 
-			double[] latRange, 
+			String label,
+			double[] latRange,
 			double[] lonRange, Constraints constraints) {
-		
+
 		this.label = label;
 		this.minlatitude = latRange[0];
 		this.maxlatitude = latRange[1];


### PR DESCRIPTION
- Swapped longitude extent for CEUS/COUS. I think this is correct.
- Potentially up for debate, I changed the order of the ENUM because the web service will use the first region that contains the input location. I would think you would prefer WUS over COUS, but maybe COUS should be the default and WUS/CEUS should be fallbacks (for custom site classes, etc...)?