### PR TITLE
Usage fix

### DIFF
--- a/src/gov/usgs/earthquake/nshm/www/services/HazardCurve.java
+++ b/src/gov/usgs/earthquake/nshm/www/services/HazardCurve.java
@@ -86,6 +86,10 @@ public class HazardCurve extends HttpServlet {
 				requestData = buildRequest(request.getParameterMap());
 			} else { // process slash-delimited request
 				List<String> params = Parsing.splitToList(pathInfo, Delimiter.SLASH);
+				java.util.Iterator<String> it = params.iterator();
+				while (it.hasNext()) {
+					System.out.println(it.next());
+				}
 				if (params.size() < 6) {
 					response.getWriter().print(HAZARD_CURVE_USAGE);
 					return;
@@ -120,12 +124,16 @@ public class HazardCurve extends HttpServlet {
 
 	/* Reduce slash-delimited request */
 	private RequestData buildRequest(List<String> params) {
+		Optional<Set<Imt>> imts = (params.get(4).equalsIgnoreCase("any")) ?
+			Optional.<Set<Imt> absent() :
+			Optional.of(readValues(params.get(4), Imt.class));
+
 		return new RequestData(
 			readValue(params.get(0), Edition.class),
 			readValue(params.get(1), Region.class),
 			Double.valueOf(params.get(2)),
 			Double.valueOf(params.get(3)),
-			Optional.of(readValues(params.get(4), Imt.class)),
+			imts,
 			Vs30.fromValue(Double.valueOf(params.get(5))));
 	}
 
@@ -156,13 +164,13 @@ public class HazardCurve extends HttpServlet {
 	/*
 	 * IMTs: PGA, SA0P20, SA1P00 TODO this need to be updated to the result of
 	 * polling all models and supports needs to be updated to specific models
-	 * 
+	 *
 	 * Editions: E2008, E2014 (maybe for dynamic calcs we just call this year
 	 * because we'll only be running the most current model, as opposed to a
 	 * specific release)
-	 * 
+	 *
 	 * Regions: COUS, WUS, CEUS, [HI, AK, GM, AS, SAM, ...]
-	 * 
+	 *
 	 * vs30: 180, 259, 360, 537, 760, 1150, 2000
 	 */
 

--- a/src/gov/usgs/earthquake/nshm/www/services/HazardCurve.java
+++ b/src/gov/usgs/earthquake/nshm/www/services/HazardCurve.java
@@ -125,7 +125,7 @@ public class HazardCurve extends HttpServlet {
 	/* Reduce slash-delimited request */
 	private RequestData buildRequest(List<String> params) {
 		Optional<Set<Imt>> imts = (params.get(4).equalsIgnoreCase("any")) ?
-			Optional.<Set<Imt> absent() :
+			Optional.<Set<Imt>> absent() :
 			Optional.of(readValues(params.get(4), Imt.class));
 
 		return new RequestData(

--- a/src/gov/usgs/earthquake/nshm/www/services/HazardCurve.java
+++ b/src/gov/usgs/earthquake/nshm/www/services/HazardCurve.java
@@ -86,10 +86,6 @@ public class HazardCurve extends HttpServlet {
 				requestData = buildRequest(request.getParameterMap());
 			} else { // process slash-delimited request
 				List<String> params = Parsing.splitToList(pathInfo, Delimiter.SLASH);
-				java.util.Iterator<String> it = params.iterator();
-				while (it.hasNext()) {
-					System.out.println(it.next());
-				}
 				if (params.size() < 6) {
 					response.getWriter().print(HAZARD_CURVE_USAGE);
 					return;

--- a/src/gov/usgs/earthquake/nshm/www/services/meta/Metadata.java
+++ b/src/gov/usgs/earthquake/nshm/www/services/meta/Metadata.java
@@ -28,7 +28,7 @@ public class Metadata {
 
 		final String status = "usage";
 		final String description = "Computes hazard curve data for an input location";
-		final String syntax = "http://localhost:8080/nshmp-haz-ws/HazardCurve/edition/region/lon/lat/imt/vs30";
+		final String syntax = "http://localhost:8080/nshmp-haz-ws/HazardCurve/{edition}/{region}/{longitude}/{latitude}/{imt}/{vs30}";
 		final Parameters parameters = new Parameters();
 
 		private class Parameters {


### PR DESCRIPTION
- Lat and lon parameters need to be spelled out (in general, we try to avoid abbreviations). In this case this is a technical implementation requirement.
- Usage syntax needs to have squiggle brace templating for the web application to function properly.
- When parsing URL parameters using the slash notation, IMT was required, but when using the query string notation IMT was optional. This makes it optional in both cases.