### PR TITLE
Test site widget with Leaflet

### DIFF
--- a/src/gov/usgs/earthquake/nshmp/www/SourceServices.java
+++ b/src/gov/usgs/earthquake/nshmp/www/SourceServices.java
@@ -230,8 +230,8 @@ public class SourceServices extends HttpServlet {
 			this.returnPeriod = new DoubleParameter(
 					"Return period (in years)",
 					ParamType.NUMBER,
-					1.0,
-					1000000.0);
+					100.0,
+					1e6);
 			
 			this.vs30 = new EnumParameter<>(
 					"Site soil (Vs30)",

--- a/webapp/apps/css/D3View.css
+++ b/webapp/apps/css/D3View.css
@@ -16,7 +16,7 @@
 }                                                                               
 
 .D3View .panel-title {
-  font-size: 1.15em;
+  font-size: 1.0em;
 }
 
 .D3View .plot-title{
@@ -63,12 +63,12 @@
 
 /* Plot panel body data table */
 .D3View .panel-table td {
-  font-size: 0.75vw;
+  font-size: 0.75em;
   vertical-align: initial;
 }
 
 .D3View .panel-table th {
-  font-size: 1vw;
+  font-size: 1em;
   font-weight: 550;
   vertical-align: initial;
   width: 50%;
@@ -79,7 +79,7 @@
 }
 
 .D3View .panel-table .data-table-title {
-  font-size: 1.25vw;
+  font-size: 1.25em;
   font-weight: 800;
 }
 

--- a/webapp/apps/css/template.css
+++ b/webapp/apps/css/template.css
@@ -9,7 +9,34 @@
 */
 
 
+/* Test Site View Class */
 
+.test-site-view .model-body {
+  padding: 0 15px;
+}
+
+.test-site-view #map-body {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  top: 0;
+}
+
+.test-site-view #site-list-body {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  overflow: scroll;
+}
+
+.test-site-view #site-list-body .form-group {
+  margin: 0;
+}
+
+.test-site-view #site-list {
+  width: 100%;
+}
 
 /*###################################################*/
 /**/
@@ -305,6 +332,16 @@ label.control-spacer {
 /**/
 /*................... Spinner .......................*/
 
+.test-site-modal.in {
+  display: grid !important;
+}
+
+.test-site-modal .modal-dialog {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
 .Spinner {
   display: grid !important;
 }
@@ -455,8 +492,6 @@ label.control-spacer {
   cursor: pointer;
 }
 /*------------------------------------------------*/
-
-
 
 
 /*------------- End: Plots ------------------------*/

--- a/webapp/apps/dynamic-compare.html
+++ b/webapp/apps/dynamic-compare.html
@@ -8,13 +8,13 @@
 
   <!-- CSS files -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" />
   
   <link rel="stylesheet" href="css/template.css" type="text/css">
   <link rel="stylesheet" href="css/D3View.css" type="text/css">
   <!-- End: CSS files --> 
 </head>
 <!-- End: Head --> 
-
 
 <!-- Body --> 
 <body>
@@ -67,6 +67,14 @@
           </div>
         </div>
         <!-- End: Logitude input -->
+        
+        <!-- Choose location on map -->
+        <div class='form-group form-group-sm'>
+          <button class="btn btn-default" id='test-site-picker' type='button'>
+            Choose a test site 
+          </button>
+        </div>
+        <!-- End: Choose location on map -->
 
         <!-- IMT select menu --> 
         <div class="form-group form-group-sm">
@@ -130,7 +138,6 @@
   <!-- End: The control panel --> 
 
 
-
   <!-- Plots --> 
   <div id="content">
   </div> 
@@ -149,7 +156,9 @@
 
   <!-- Application Specific JavaScript -->
   <script src="https://d3js.org/d3.v4.min.js"></script>
-  
+  <script src="https://d3js.org/topojson.v2.min.js"></script>
+  <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
+   
   <script type='module'>
     import Config from './js/lib/Config.js';
     import DynamicCompare from './js/DynamicCompare.js';

--- a/webapp/apps/geo-deagg.html
+++ b/webapp/apps/geo-deagg.html
@@ -6,6 +6,7 @@
   <meta charset="UTF-8">   
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" />
   <link rel="stylesheet" href="css/template.css" type="text/css">
   <link rel="stylesheet" href="css/D3View.css" type="text/css">
 </head>
@@ -56,6 +57,14 @@
             <div class="input-group-addon">&#176;</div>
           </div>
         </div>
+        
+        <!-- Choose location on map -->
+        <div class='form-group form-group-sm'>
+          <button class="btn btn-default" id='test-site-picker' type='button'>
+            Choose a test site
+          </button>
+        </div>
+        <!-- End: Choose location on map -->
 
         <!-- Itensity measure type select menu  -->
         <div class="form-group form-group-sm">
@@ -126,7 +135,8 @@
   <script src="https://d3js.org/d3.v4.min.js"></script>
   <script src="https://d3js.org/topojson.v1.min.js"></script>
 	<script src="https://d3js.org/d3-geo-projection.v2.min.js"></script>
-  
+  <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
+   
   <!-- Application specific JavaScript --> 
   <script type='module'>
     import Config from './js/lib/Config.js';

--- a/webapp/apps/js/Dashboard.js
+++ b/webapp/apps/js/Dashboard.js
@@ -50,9 +50,6 @@ export default class Dashboard {
         label: 'Response Spectra',
         href: 'apps/spectra-plot.html',
       }, {
-        label: 'Test Sites', 
-        href: 'apps/test-sites.html',
-      }, {
         label: 'Services',
         href: 'apps/services.html',
       }

--- a/webapp/apps/js/GeoDeagg.js
+++ b/webapp/apps/js/GeoDeagg.js
@@ -4,6 +4,7 @@ import Constraints from './lib/Constraints.js';
 import D3GeoDeagg from './lib/D3GeoDeagg.js';
 import Footer from './lib/Footer.js';
 import Header from './lib/Header.js';
+import LeafletTestSitePicker from './lib/LeafletTestSitePicker.js';
 import Spinner from './lib/Spinner.js';
 import Tools from './lib/Tools.js';
 
@@ -93,6 +94,8 @@ export default class GeoDeagg {
     /** @type {HTMLElement} */
     this.returnPeriodBtnsEl = document.querySelector('#return-period-btns');
     /** @type {HTMLElement} */
+    this.testSitePickerBtnEl = document.querySelector('#test-site-picker');
+    /** @type {HTMLElement} */
     this.vs30El = document.querySelector('#vs30');
 
     /** @type {D3GeoDeagg} */
@@ -123,6 +126,17 @@ export default class GeoDeagg {
     
     // Listen for all control panel changes
     this.onInputChange(); 
+  
+    /* @type {LeafletTestSitePicker} */
+    this.testSitePicker = new LeafletTestSitePicker(
+        this.latEl,
+        this.lonEl,
+        this.testSitePickerBtnEl);
+
+    /* Bring Leaflet map up when clicked */                                     
+    $(this.testSitePickerBtnEl).on('click', (event) => {                        
+      this.testSitePicker.plotMap(this.regionEl.value);
+    });
   }
   
   /**
@@ -177,7 +191,9 @@ export default class GeoDeagg {
     // Update menus when region is changed
     this.onRegionChange();  
     // Check URL for parameters
-    this.checkQuery();
+    this.testSitePicker.on('testSiteLoad', (event) => {
+      this.checkQuery();
+    });
   }
 
   /**
@@ -554,7 +570,15 @@ export default class GeoDeagg {
       // Where the map should rotate to
       let rotate = [-lon, -lat, 0];
       
-      this.plot.setPlotTitle('Geographic Deaggregation')
+      let siteTitle = this.testSitePicker
+          .getTestSiteTitle(this.regionEl.value);
+      let vs30 = $(':selected', this.vs30El).text();
+      let imt = $(':selected', this.imtEl).text();
+      let edition = $(':selected', this.editionEl).text();
+
+      let title = edition + ', ' + siteTitle + ', ' + imt + ', ' + vs30;
+
+      this.plot.setPlotTitle(title)
           .setSiteLocation({latitude: lat, longitude: lon})
           .setMetadata(metadata)
           .setUpperData(seriesData)

--- a/webapp/apps/js/ModelCompare.js
+++ b/webapp/apps/js/ModelCompare.js
@@ -96,8 +96,10 @@ export default class ModelCompare extends Hazard{
   //......................... Method: buildInputs ..............................
   static buildInputs(_this){
     _this.spinner.off();
-
-    ModelCompare.checkQuery(_this);
+    
+    _this.testSitePicker.on('testSiteLoad', (event) => { 
+      ModelCompare.checkQuery(_this);
+    });
     
     ModelCompare.setParameterMenu(_this,"region",_this.comparableRegions);
     ModelCompare.setBounds(_this);
@@ -190,7 +192,13 @@ export default class ModelCompare extends Hazard{
     
     var selectedImtDisplay = _this.imtEl.querySelector(":checked").text; 
     var selectedImtValue   = _this.imtEl.value; 
-    let title = "Hazard Curves at " + selectedImtDisplay; 
+    
+    let imt = $(':selected', _this.imtEl).text();
+    let vs30 = $(':selected', _this.vs30El).text();
+    let siteTitle = _this.testSitePicker
+        .getTestSiteTitle(_this.regionEl.value);
+
+    let title = siteTitle + ', ' + imt + ', ' + vs30; 
     let filename = "hazardCurves-"+selectedImtValue;
 
     var seriesData = [];       

--- a/webapp/apps/js/ModelExplorer.js
+++ b/webapp/apps/js/ModelExplorer.js
@@ -85,7 +85,10 @@ export default class ModelExplorer extends Hazard{
   //......................... Method: buildInputs ..............................
   static buildInputs(_this){
     _this.spinner.off();
-    ModelExplorer.checkQuery(_this);
+    
+    _this.testSitePicker.on('testSiteLoad', (event) => {
+      ModelExplorer.checkQuery(_this);
+    });
 
     let editionValues = _this.parameters.edition.values;
     ModelExplorer.setParameterMenu(_this,"edition",editionValues);
@@ -108,6 +111,7 @@ export default class ModelExplorer extends Hazard{
       supportedVs30 = ModelExplorer.supportedValues(_this,"vs30") 
       ModelExplorer.setParameterMenu(_this,"imt",supportedImt);
       ModelExplorer.setParameterMenu(_this,"vs30",supportedVs30);
+      _this.testSitePicker.checkForRegion(_this.regionEl.value);
     });
           
     $(_this.regionEl).change(function(){
@@ -117,6 +121,7 @@ export default class ModelExplorer extends Hazard{
       supportedVs30 = ModelExplorer.supportedValues(_this,"vs30") 
       ModelExplorer.setParameterMenu(_this,"imt",supportedImt);
       ModelExplorer.setParameterMenu(_this,"vs30",supportedVs30);
+      _this.testSitePicker.checkForRegion(_this.regionEl.value);
      });
     
     $(_this.controlEl).removeClass('hidden');
@@ -175,7 +180,12 @@ export default class ModelExplorer extends Hazard{
     $(_this.hazardPlot.legendEl).off();
     $(_this.hazardPlot.allDataEl).off();
     
-    let title = "Hazard Curves";
+    let imt = $(':selected', _this.imtEl).text();
+    let vs30 = $(':selected', _this.vs30El).text();
+    let siteTitle = _this.testSitePicker
+        .getTestSiteTitle(_this.regionEl.value);
+    
+    let title = siteTitle + ', ' + imt + ', ' + vs30;
     let filename = "hazardCurves";
     var seriesData = [];
     var seriesLabels = [];
@@ -288,7 +298,13 @@ export default class ModelExplorer extends Hazard{
     metadata.time = new Date();
     
     let imtSelectedDisplay = _this.imtEl.querySelector(":checked").text; 
-    let title = "Component Curves at "+ imtSelectedDisplay
+    
+    let imt = $(':selected', _this.imtEl).text();
+    let vs30 = $(':selected', _this.vs30El).text();
+    let siteTitle = _this.testSitePicker
+        .getTestSiteTitle(_this.regionEl.value);
+    
+    let title = siteTitle + ', ' + imt + ', ' + vs30;
     let filename = "componentCurve-"+_this.imtEl.value;
     var seriesData = [];
     var seriesLabels = [];

--- a/webapp/apps/js/lib/D3LinePlot.js
+++ b/webapp/apps/js/lib/D3LinePlot.js
@@ -420,6 +420,9 @@ export default class D3LinePlot extends D3View {
       [xMin, xMax] = [-1.0, 1.0] 
     }
     
+    xMin = isNaN(xMin) ? 0 : xMin;
+    xMax = isNaN(xMax) ? 1 : xMax; 
+    
     return [xMin, xMax];   
   }
   
@@ -472,7 +475,10 @@ export default class D3LinePlot extends D3View {
       });
       return tmp;
     });
-    
+   
+    yMin = isNaN(yMin) ? 0 : yMin;
+    yMax = isNaN(yMax) ? 1 : yMax; 
+     
     return yMin == yMax ? [yMin / 1.1, yMax * 1.1] : [yMin, yMax];
   }
   

--- a/webapp/apps/js/lib/D3MapPlot.js
+++ b/webapp/apps/js/lib/D3MapPlot.js
@@ -285,7 +285,8 @@ export default class D3MapPlot extends D3MapView{
         .attr("class","user-added-sites");
     //--------------------------------------------------------------------------
     
-
+    
+    /*
     //...................... Site List Events ..................................  
     d3.select(mapPlot.siteListEl)
         .selectAll("label")
@@ -310,7 +311,7 @@ export default class D3MapPlot extends D3MapView{
           tooltip.destroy(mapPlot);
         });
     //--------------------------------------------------------------------------
-  
+    */
 
     //....................... Snap to Event ....................................
     d3.select(mapPlot.snapToEl).on("change",function(){

--- a/webapp/apps/js/lib/D3SaveFigure.js
+++ b/webapp/apps/js/lib/D3SaveFigure.js
@@ -313,13 +313,13 @@ export default class D3SaveFigure {
       
     svgD3.select('.plot')
         .attr('transform', plotTransform);
-    
+   
     // Add plot title 
     if (this.options.printTitle) {
       svgD3.select('.plot')      
           .append('text')
           .attr('class', 'plot-title')
-          .attr('x', this.originalPlotWidth / 2)
+          .attr('x', (this.originalPlotWidth - this.originalPlotMarginLeft) / 2)
           .attr('y', -40)
           .attr('text-anchor', 'middle')
           .attr('alignment-baseline', 'text-after-edge')
@@ -382,7 +382,9 @@ export default class D3SaveFigure {
 
     let iframeD3 = d3.select('body')
         .append('iframe')
-        .attr('class', 'hidden save-figure-iframe-' + this.filename);
+        .attr('class', 'save-figure-iframe-' + this.filename)
+        .style('height', '0px')
+        .style('width', '0px');
     
     let iframeEl = iframeD3.node();
     

--- a/webapp/apps/js/lib/D3TestSitePlot.js
+++ b/webapp/apps/js/lib/D3TestSitePlot.js
@@ -1,0 +1,351 @@
+'use strict';
+
+import TestSiteView from './TestSiteView.js';
+import D3Tooltip from './D3Tooltip.js';
+
+/**
+* Place holder class. 
+*
+* TODO: 
+*   Make work with TestSiteView.
+*/
+export default class D3TestSitePlot extends TestSiteView {
+
+  constructor(latEl, lonEl, btnEl) {
+
+    super(latEl, lonEl, btnEl);
+      
+    this.mapBorderUrl = '/nshmp-haz-ws/data/us.json';
+    this.mapUrl = '/nshmp-haz-ws/data/americas.json';
+    
+    this.options = {                                                            
+      backgroundColor: '#C0C0C0',                                               
+      mapFill: 'white',                                                         
+      mapStroke: 'black',                                                       
+      mapStrokeWidth: 2,                                                        
+      mapBorderStroke: 'black',                                                 
+      mapBorderStrokeWidth: 1,                                                  
+      plotHeight: 700,                                                          
+      plotWidth: 900,                                                           
+      siteColor: 'black',                                                       
+      siteSelectedColor: 'red',                                                 
+      siteSize: 3,                                                              
+      tooltipText: ['', 'Longitude (°): ', 'Latitude (°): '],                   
+    }; 
+
+    this.svgEl = this.createSvgStructure();
+    this.plotEl = this.svgEl.querySelector('.plot');
+    this.tooltipEl = this.svgEl.querySelector('.d3-tooltip');
+    this.americasEl = this.svgEl.querySelector('.americas');
+    this.bordersEl = this.svgEl.querySelector('.borders');
+    this.testSitesEl = this.svgEl.querySelector('.testsites');
+
+    this.projection = d3.geoMercator();
+        
+    this.path = d3.geoPath()
+        .projection(this.projection);
+    
+    this.getUsage();
+  }
+ 
+  /**
+  * @method createSvgStructure
+  */
+  createSvgStructure() {
+    let viewBox = '0, 0, ' + this.options.plotWidth +
+        ', ' + this.options.plotHeight;
+    let svgD3 = d3.select(this.mapBodyEl)
+        .append('svg')
+        .attr('class', 'D3TestSiteMap')
+        .attr('version', 1.1)
+        .attr('xmlns', 'http://www.w3.org/2000/svg')
+        .attr('preserveAspectRatio', 'xMinYMin meet')
+        .attr('viewBox', viewBox)
+        .style('margin-bottom', '-5px');
+    
+    let mapD3 = svgD3.append('g')
+        .attr('class', 'plot');
+    
+    mapD3.append('g')
+        .attr('class', 'd3-tooltip');
+    
+    mapD3.append('g')
+        .attr('class', 'americas');
+    
+    mapD3.append('g')
+        .attr('class', 'borders');
+    
+    mapD3.append('g')
+        .attr('class', 'testsites');
+    
+    return svgD3.node();
+  }
+  
+  /**
+  * @method getUsage
+  */
+  getUsage() {
+    let testSitePromise = $.getJSON(this.webServiceUrl);
+    let mapBorderPromise = $.getJSON(this.mapBorderUrl);
+    let mapPromise = $.getJSON(this.mapUrl);
+    let promises = [
+        testSitePromise,
+        mapPromise,
+        mapBorderPromise,
+    ];
+    
+    $.when(testSitePromise, mapPromise, mapBorderPromise)
+    .done((usage, map, mapBorder) => {
+      let usBorders = topojson.mesh(
+          mapBorder[0], mapBorder[0].objects.states,
+          (a, b) => { return a !== b; });
+      let americas = map[0].features;
+      
+      this.testSites = usage[0].features;
+      this.usBorders = usBorders;
+      this.americas = americas;
+      
+      this.updateButton();
+    })
+    .fail((err) => {
+      console.log('getUsage: JSON error - ' + err);
+    });
+  }
+  
+  /**
+  * @method plotMap
+  */
+  plotData(regionId) {
+    d3.select(this.useLocationBtnEl)
+        .property('disabled', true); 
+    
+    let testSiteData = this.testSites.filter((feature) => {
+      return feature.properties.regionId == regionId;
+    })[0];
+    this.createSiteList(testSiteData);
+        
+    let regionBounds = testSiteData.properties.regionBounds;
+
+    this.projection.fitSize(
+        [this.options.plotWidth, this.options.plotHeight],
+        regionBounds);
+
+    this.plotAmericas();
+    this.plotStateBorders();
+    this.plotTestSites(testSiteData);
+   
+    this.onSiteSelect(); 
+    this.onSnapGrid();
+   
+    this.onUseLocation();
+  }
+   
+  /**
+  * @method plotAmericas
+  */
+  plotAmericas() {
+    d3.select(this.americasEl)
+        .selectAll('path')
+        .remove();
+
+    d3.select(this.americasEl)
+        .selectAll('path')
+        .data(this.americas)
+        .enter()
+        .append('path')
+        .attr('class', 'america-map')
+        .attr('d', this.path)
+        .attr('fill', this.options.mapFill)
+        .attr('stroke', this.options.mapStroke)
+        .attr('stroke-width', this.mapStrokeWidth)
+        .attr('stroke-linejoin', 'round');
+  }
+  
+  /**
+  * @method plotStateBorders
+  *
+  */ 
+  plotStateBorders() {
+    d3.select(this.bordersEl)
+        .selectAll('path')
+        .remove();
+    
+    d3.select(this.bordersEl)
+        .append('path')
+        .attr('d', this.path(this.usBorders))
+        .attr('fill', 'none')
+        .attr('stroke', this.options.mapBorderStroke)
+        .attr('stroke-width', this.options.mapBorderStrokeWidth)
+        .attr('stroke-linejoin', 'round');
+  }
+
+  /**
+  * @method plotTestSites
+  */
+  plotTestSites(testSiteData) {
+    d3.select(this.testSitesEl)
+        .selectAll('path')
+        .remove();
+    
+    d3.select(this.testSitesEl)
+        .selectAll('path')
+        .data(testSiteData.features)
+        .enter()
+        .append('path')
+        .classed('selected', (d, i) => {
+          let coords = this.getCoordinates(d);
+          return coords[0] == this.lonEl.value && 
+              coords[1] == this.latEl.value ? 
+              true : false;
+        })
+        .attr('d', (d, i) => {
+          let coords = this.getCoordinates(d); 
+          let data = JSON.parse(JSON.stringify(d));
+          data.geometry.coordinates = coords;
+          return this.path(data);
+        })
+        .attr('id', (d, i) => { return d.properties.locationId; })
+        .attr('stroke', this.options.siteColor)
+        .attr('fill', this.options.siteColor)
+        .attr('stroke-width', this.options.siteSize)
+        .style('cursor', 'pointer')
+        .filter((d, i, els) => {
+          let isSelected = d3.select(els[i]).classed('selected');
+          if (isSelected) {
+            d3.select(this.useLocationBtnEl)
+                .property('disabled', false);
+          }
+
+          return isSelected;
+        })
+        .attr('stroke', this.options.siteSelectedColor)
+        .attr('fill', this.options.siteSelectedColor);
+
+    this.createTooltip();
+  }
+
+  /**
+  * @method onSiteSelect
+  *
+  * If a test site is clicked update the value of the latitude element
+  *     and longitude element and trigger an input event as if
+  *     a user updated the field.
+  */
+  onSiteSelect() {
+    d3.select(this.testSitesEl)
+        .selectAll('path')
+        .on('click', (d, i, els) => {
+          d3.select(this.testSitesEl)
+              .selectAll('path')
+              .classed('selected', false)
+              .attr('stroke', this.options.siteColor)
+              .attr('fill', this.options.siteColor);
+               
+          d3.select(els[i])
+              .classed('selected', true)
+              .attr('stroke', this.options.siteSelectedColor)
+              .attr('fill', this.options.siteSelectedColor);
+          
+          d3.select(this.useLocationBtnEl)
+              .property('disabled', false);
+        });
+  }
+
+  /**
+  * @method createTooltip
+  *
+  * Create a tooltip using the D3Tooltip class when a test site 
+  *     is hovered.
+  */
+  createTooltip() {
+    let tooltip;
+
+    d3.select(this.testSitesEl)
+        .selectAll('path')
+        .on('mouseover', (d, i, els) => {
+          let coords = this.getCoordinates(d);
+           
+          let mouseCoords = this.projection(coords);
+          let cx = mouseCoords[0];
+          let cy = mouseCoords[1];
+
+          let tooltipText = [
+            this.options.tooltipText[0] + d.properties.location,
+            this.options.tooltipText[1] + coords[0],
+            this.options.tooltipText[2] + coords[1],
+          ]; 
+          
+          tooltip = new D3Tooltip.Builder()
+              .coordinates(cx, cy)
+              .dataEl(els[i])
+              .plotHeight(this.options.plotHeight)
+              .plotWidth(this.options.plotWidth)
+              .tooltipText(tooltipText)
+              .tooltipEl(this.tooltipEl)
+              .build();
+        })
+        .on('mouseout', () => {
+          tooltip.remove();
+        });
+  }
+
+  /**
+  * @method onSnapGrid
+  *
+  * Listen for the snap grid checkbox to be clicked and replot the 
+  *     test sites.
+  */
+  onSnapGrid() {
+    $(this.snapGridEl).off();
+    $(this.snapGridEl).on('click', (event) => {
+      this.updateTestSites();
+    });
+  }
+  
+  /**
+  * @method updateTestSites
+  * 
+  * Replot the test sites
+  */ 
+  updateTestSites() {
+    d3.select(this.testSitesEl)
+        .selectAll('path')
+        .attr('d', (d, i) => {
+          let coords = this.getCoordinates(d);
+          let data = JSON.parse(JSON.stringify(d));
+          data.geometry.coordinates = coords;
+          return this.path(data);
+        });
+  }
+ 
+  /**
+  * @method getSelectedSite
+  *
+  * Find the site that is currently selected on the map.
+  */                                                                            
+  getSelectedSite() {
+    let selectedSiteEl = $('.selected', this.testSitesEl)[0];
+    
+    return selectedSiteEl == undefined ? null : selectedSiteEl;
+  }
+
+  /**
+  * @method onUseLocation
+  */
+  onUseLocation() {
+    $(this.useLocationBtnEl).on('click', (event) => {
+      let selectedSiteEl = this.getSelectedSite();
+      let data = d3.select(selectedSiteEl).data()[0];
+      let coords = this.getCoordinates(data);
+      
+      this.lonEl.value = coords[0];
+      this.latEl.value = coords[1];
+      
+      $(this.latEl).trigger('input');
+      $(this.lonEl).trigger('input');
+      
+      $(this.el).modal('hide');
+    });
+  }
+
+}

--- a/webapp/apps/js/lib/D3Tooltip.js
+++ b/webapp/apps/js/lib/D3Tooltip.js
@@ -162,6 +162,29 @@ export default class D3Tooltip {
   }
 
   /**
+  * @method pointColor
+  *
+  * Change the dot color
+  * @param {String} color - The color the dot should be
+  */
+  pointColor(color) {
+    d3.select(this.selectedEl)
+        .attr('fill', color);
+  }
+    
+  /**
+  * @method remove
+  *
+  * Method to remove the tooltip
+  * @param {Panel} panel - Upper or lower panel object
+  */
+  remove() {
+    d3.select(this.tooltipEl)
+        .selectAll("*")
+        .remove();
+  }
+ 
+  /**
   * @method tooltipLocation 
   *
   * Find best location to put the tooltip
@@ -188,15 +211,4 @@ export default class D3Tooltip {
     return 'translate(' + xRect + ',' + yRect + ')'; 
   }
 
-  /**
-  * @method pointColor
-  *
-  * Change the dot color
-  * @param {String} color - The color the dot should be
-  */
-  pointColor(color) {
-    d3.select(this.selectedEl)
-        .attr('fill', color);
-  }
-    
 }

--- a/webapp/apps/js/lib/D3View.js
+++ b/webapp/apps/js/lib/D3View.js
@@ -251,7 +251,7 @@ export default class D3View {
       showLegend: true,
       tickFontSize: 12,
       tickExponentFontSize: 10,
-      titleFontSize: 20,
+      titleFontSize: 16,
       tooltipFontSize: 12,
       tooltipOffsetX: 2,
       tooltipOffsetY: 8,

--- a/webapp/apps/js/lib/Hazard.js
+++ b/webapp/apps/js/lib/Hazard.js
@@ -2,6 +2,7 @@
 
 import Footer from './Footer.js';
 import Header from './Header.js';
+import LeafletTestSitePicker from './LeafletTestSitePicker.js';
 import Settings from './Settings.js';
 import Spinner from './Spinner.js';
 
@@ -41,15 +42,15 @@ export default class Hazard{
 
     this.config = config;
 
-    $(_this.lonEl).change(function(){
+    $(_this.lonEl).on('input', (event) => {
       Hazard.checkCoordinates(_this,false,true);
     });
     
-    $(_this.latEl).change(function(){
+    $(_this.latEl).on('input', (event) => {
       Hazard.checkCoordinates(_this,true,false);
     });
 
-    $(_this.controlEl).change(function(){
+    $(_this.controlEl).on('input change', (event) => {
       let canSubmit = Hazard.checkCoordinates(_this,false,false);
       _this.footerOptions = {
         updateBtnDisable: !canSubmit
@@ -59,6 +60,19 @@ export default class Hazard{
  
     this.dynamicUrl = this.config.server.dynamic + "/nshmp-haz-ws/hazard";
     this.staticUrl  = this.config.server.static + "/hazws/staticcurve/1";
+    
+    this.testSitePickerBtnEl = document.querySelector('#test-site-picker');
+  
+    /* @type {LeafletTestSitePicker} */
+    this.testSitePicker = new LeafletTestSitePicker(
+        this.latEl,
+        this.lonEl,
+        this.testSitePickerBtnEl);
+    
+    /* Bring Leaflet map up when clicked */
+    $(this.testSitePickerBtnEl).on('click', (event) => {
+      this.testSitePicker.plotMap(this.regionEl.value);
+    });
   }
 
 

--- a/webapp/apps/js/lib/HazardNew.js
+++ b/webapp/apps/js/lib/HazardNew.js
@@ -136,6 +136,7 @@ export default class Hazard {
   getUsage(callback = () => {}) {
     this.callback = callback;
     let promise = $.getJSON(this.webServiceUrl);
+    this.spinner.on(promise);
 
     promise.done((usage) => {
       this.parameters = usage.parameters;

--- a/webapp/apps/js/lib/Header.js
+++ b/webapp/apps/js/lib/Header.js
@@ -55,9 +55,6 @@ export default class Header{
         label: 'Response Spectra', 
         href: '/nshmp-haz-ws/apps/spectra-plot.html',
       }, {
-        label: 'Test Sites', 
-        href: '/nshmp-haz-ws/apps/test-sites.html',
-      }, {
         label: 'Services',  
         href: '/nshmp-haz-ws/apps/services.html',
       }

--- a/webapp/apps/js/lib/LeafletTestSitePicker.js
+++ b/webapp/apps/js/lib/LeafletTestSitePicker.js
@@ -1,0 +1,481 @@
+'use strict';
+
+import TestSiteView from './TestSiteView.js';
+import Tools from './Tools.js';
+
+/**
+* @class LeafletTestSitePicker
+* @extends TestSiteView
+*
+* @fileoverview Location widget to choose a test site.
+*
+* @author Brandon Clayton
+*/
+export default class LeafletTestSitePciker extends TestSiteView {
+
+  /**
+  * @param {HTMLElement} latEl - The HTML element associated with the
+  *     latitude input.
+  * @param {HTMLElement} lonEl - The HTML element associated with the 
+  *     longitude input.
+  * @param {HTMLElement} activationBtnEl - The HTML element associated with 
+  *     a button that onced pressed would show the location widget.
+  */
+  constructor(latEl, lonEl, activationBtnEl) {
+    super(latEl, lonEl, activationBtnEl);
+   
+    /** @type {Object} */
+    this.options = { 
+      plotHeight: 1280,
+      plotWidth: 1024,
+      map: {
+        minZoom: 1,
+        maxZoom: 18,
+        zoomSnap: 0.5,
+      },
+      site: {
+        radius: 4,
+        color: 'black',
+        opactiy: 1,
+        fillOpacity: 1,
+        className: '',
+      },
+      siteSelected: {
+        radius: 4,
+        color: 'red',
+        opactiy: 1,
+        fillOpacity: 1,
+        className: 'selected',
+      },
+      fitBounds: {
+        animate: false,
+      },
+    };
+  
+    /** @type {HTMLElement} */ 
+    this.svgEl = this.createSvgStructure(); 
+    /** @type {HTMLElement} */ 
+    this.leafletEl = this.mapBodyEl;
+    /** @type {LeafletMap} */
+    this.leafletMap = this.createBaseMap();
+    /** @type {LeafletGeoJsonLayer} */
+    this.geoJsonLayer = this.createGeoJson();
+    
+    /* Get test sites */ 
+    this.getUsage();
+   
+    /** @type {EventListner} */
+    this.on = document.addEventListener.bind(document); 
+
+    /** 
+    * @type {CustomEvent} New custom event to be called
+    *     as this.on('testSiteLoad', () => {}). Gets triggered
+    *     after the test sites have been loaded.
+    */   
+    this.onTestSiteLoadEvent = new CustomEvent(
+        'testSiteLoad', 
+        {bubbles: true, cancelable: true});
+  }
+  
+  /**
+  * @method checkForRegion
+  *
+  * Check if a region exists in the test sites and disabled button if
+  *     there is no region.
+  */
+  checkForRegion(regionId) {
+    let region = this.getRegion(regionId);
+    if (region == undefined) {
+      d3.select(this.activationBtnEl)
+          .property('disabled', true);
+    } else {
+      d3.select(this.activationBtnEl)
+          .property('disabled', false);
+    }
+  }
+  
+  /**
+  * @method createBaseMap
+  *
+  * Create the Leaflet base map with greyscale, street, and satellite layers.
+  * @return {LeafletMap} The leaflet map.
+  */
+  createBaseMap() {
+    let mapUrl = 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}@2x.png' +
+        '?access_token={accessToken}';
+    
+    let mapToken = 'pk.eyJ1IjoiYmNsYXl0b24iLCJhIjoiY2pmbWxmd3BhMHg1eTJ' + 
+        '4bzR3M2Q3ZTM5YyJ9.lCQ8B6C9xhpZmd8BrukbDw';
+    
+    /* Greyscale layer */
+    let greyscale = L.tileLayer(mapUrl, {
+      accessToken: mapToken,
+      id: 'mapbox.light',
+    });
+    
+    /* Street layer */
+    let street = L.tileLayer(mapUrl, {
+      accessToken: mapToken,
+      id: 'mapbox.streets',
+    });
+    
+    /* Satellite layer */
+    let satellite = L.tileLayer(mapUrl, {
+      accessToken: mapToken,
+      id: 'mapbox.satellite',
+    });
+   
+    /* Topography layer */
+    let topography = L.tileLayer(mapUrl, {
+      accessToken: mapToken,
+      id: 'mapbox.outdoors',
+    });
+
+    /* Pirate layer */
+    let pirate = L.tileLayer(mapUrl, {
+      accessToken: mapToken,
+      id: 'mapbox.pirates',
+    });
+    
+    /* Create the map */
+    let leafletMap = L.map(this.leafletEl, {
+      center: [0, 0],
+      zoom: 0,
+      layers: [greyscale],
+      minZoom: this.options.map.minZoom,
+      maxZoom: this.options.map.maxZoom,
+      zoomSnap: this.options.map.zoomSnap,
+    });
+    
+    /* Base maps */
+    let baseMaps = {
+      'Greyscale': greyscale,
+      'Street': street,
+      'Satellite': satellite,
+      'Topography': topography,
+      'Pirate': pirate,
+    };
+    
+    /* Add layers to Leaflet map */
+    L.control.layers(baseMaps, null).addTo(leafletMap);
+    
+    return leafletMap;
+  }
+
+  /**
+  * @method createGeoJson
+  * 
+  * Create an empty Leaflet GeoJson layer to add test sites to.
+  * Test sites are rendered in SVG.
+  * @return {LeafletGeoJsonLayer} The GeoJson layer.
+  */ 
+  createGeoJson() {
+    let geoJsonLayer = L.geoJSON(null, {
+      /* 
+      * Render test site in SVG. 
+      * See if lat and lon values match a 
+      *     test site and use selected site options if so.
+      */
+      pointToLayer: (feature, latlng) => {
+        let coords = this.getCoordinates(feature);
+        latlng.lng = coords[0];
+        latlng.lat = coords[1];
+        let options = this.options.site;
+                
+        if (this.lonEl.value == coords[0] && 
+            this.latEl.value == coords[1]) {
+          d3.select(this.useLocationBtnEl)
+              .property('disabled', false);
+          
+          d3.select(this.siteListEl)
+              .select('#' + feature.properties.locationId)
+              .classed('active', true)
+              .node()
+              .scrollIntoView();
+          
+          options = this.options.siteSelected;
+        } 
+
+        return L.circleMarker(latlng, options);
+      },
+      /* Create tooltips for each location. */
+      onEachFeature: (feature, layer) => {
+        let coords = this.getCoordinates(feature);
+        let tooltip = '<b> ' + feature.properties.location + '</b><br>' +
+            'Longitude: ' + coords[0] + '<br>' +
+            'Latitude: ' + coords[1];
+        
+        layer.bindTooltip(tooltip);     
+      },
+    });
+    
+    geoJsonLayer.addTo(this.leafletMap);
+    
+    return geoJsonLayer;
+  }
+ 
+  /**
+  * @method createSvgStructure
+  *
+  * Create a responsive SVG structure as the Leaflet frame.
+  * @return {HTMLElement} The SVG element.
+  */
+  createSvgStructure() {
+    let viewBox = '0, 0, ' + this.options.plotWidth +
+        ', ' + this.options.plotHeight;
+    let svgD3 = d3.select('.modal-body')
+        .append('svg')
+        .attr('class', 'leaflet-frame')
+        .attr('version', 1.1)
+        .attr('xmlns', 'http://www.w3.org/2000/svg')
+        .attr('preserveAspectRatio', 'xMinYMin meet')
+        .attr('viewBox', viewBox)
+        .style('margin-bottom', '-5px')
+        .style('width', this.viewOptions.mapWidth);
+    
+    return svgD3.node();                                                        
+  }
+
+  /**
+  * @method findTestSite
+  *
+  * Search all test sites in a particular region 
+  *     to see if the current lat and lon values match a test site.
+  * @return {Object || Undefined} The test site. 
+  */ 
+  findTestSite(regionId) {
+    let region = this.getRegion(regionId);
+
+    let site = region.features.find((site) => {
+      let coords = this.getCoordinates(site);
+      return this.lonEl.value == coords[0] &&
+          this.latEl.value == coords[1];
+    });
+    
+    return site != undefined ? site : undefined; 
+  }
+
+  /**
+  * @method getSelectedSiteFromClassName
+  *
+  * Find a selected test site based on the class name 
+  *     attribute.
+  */
+  getSelectedSiteFromClassName() {
+    let layers = this.geoJsonLayer.getLayers();
+    let selectedLayer = layers.find((layer) => {
+      return layer.options.className == 
+          this.options.siteSelected.className;
+    });
+    
+    return selectedLayer.feature; 
+  }
+
+  /**
+  * @method getSelectedSiteFromId
+  *
+  * Find a selected site based on the location id
+  */  
+  getSelectedSiteFromId(locationId) {
+    let layers = this.geoJsonLayer.getLayers();
+    let selectedLayer = layers.find((layer) => {
+      return layer.feature.properties.locationId == locationId
+    });
+ 
+    return selectedLayer; 
+  }
+
+  /**
+  * @method getTestSiteTitle 
+  *
+  * Find a test site that matched current lat and lon values
+  *     and return a string as: 'Location (lon, lat)'
+  * If the lat and lon values do not match a test site then 
+  *     return just lat and lon value as string.
+  * @return {String} The location string.    
+  */
+  getTestSiteTitle(regionId) {
+    let testSite = this.findTestSite(regionId);
+    let loc = testSite != undefined ? testSite.properties.location : '';
+
+    return loc + ' (' + this.lonEl.value + ', ' + this.latEl.value + ')';
+  }
+
+  /**
+  * @method getUsage
+  *
+  * Get the test sites from /nshmp-haz-ws/util/testsites.
+  * Update the activationBtnEl to be clickable.
+  * Trigger the custom event on('testSiteLoad').
+  */
+  getUsage() {
+    let promise = $.getJSON(this.webServiceUrl);
+    promise.done((usage) => {
+      this.testSites = usage.features;
+      document.dispatchEvent(this.onTestSiteLoadEvent);
+      d3.select(this.activationBtnEl)
+          .property('disabled', false);
+    })
+    .fail((err) => {
+      console.log('getUsage: JSON error - ' + err);
+    });
+  }
+  
+  /**
+  * @method onSiteListSelect
+  *
+  * Listen for a mouseover, mouseout, and mousedown on the 
+  *     site list.
+  * Mousedown: Update the corresponding site in the map with 
+  *     this.options.selectedSite
+  * Mouseover: Show the tooltip on the corresponding site in the map.
+  * Mouseout: Remove tooltip.
+  */
+  onSiteListSelect() {
+    /* 
+    * Update options to options.selectedSite when
+    *     site list clicked. 
+    */
+    $(this.siteListEl).on('mousedown keyup keydown', (event) => {
+      let locationId = event.target.value || event.target.id;
+      let selectedLayer = this.getSelectedSiteFromId(locationId); 
+      this.geoJsonLayer.setStyle(this.options.site);
+      selectedLayer.setStyle(this.options.siteSelected);  
+      selectedLayer.bringToFront();
+      
+      d3.select(this.useLocationBtnEl)
+          .property('disabled', false);
+    });
+  
+    /* Show tooltip on site in map */
+    $(this.siteListEl).on('mouseover', (event) => {
+      let locationId = event.target.value || event.target.id;
+      let selectedLayer = this.getSelectedSiteFromId(locationId); 
+      
+      selectedLayer.bringToFront()
+          .openTooltip();
+    });
+    
+    /* Remove tooltip */
+    $(this.siteListEl).on('mouseout', (event) => {
+      let locationId = event.target.value || event.target.id;
+      let selectedLayer = this.getSelectedSiteFromId(locationId); 
+      selectedLayer.closeTooltip();
+    });
+  }
+
+  /**
+  * @method onSiteSelect
+  * 
+  * Listen for a test site to be clicked and update the options
+  *     using this.options.siteSelected and select the
+  *     site in the site list and scroll it into view.
+  */
+  onSiteSelect() {
+    this.geoJsonLayer.on('click', (event) => {
+      this.geoJsonLayer.setStyle(this.options.site);
+      let layer = event.layer;
+      layer.setStyle(this.options.siteSelected);
+      
+      d3.select(this.siteListEl)
+          .selectAll('label')
+          .classed('active', false);
+
+      d3.select(this.siteListEl)
+          .select('#' + layer.feature.properties.locationId)
+          .classed('active', true)
+          .node()
+          .scrollIntoView();
+
+      d3.select(this.useLocationBtnEl)
+          .property('disabled', false);
+    });
+  }
+  
+  /**
+  * @method onSnapGrid
+  * 
+  * Place holder method for when the snap to grid is check.
+  */
+  onSnapGrid() {
+    $(this.snapGridEl).off();
+    $(this.snapGridEl).on('click', (event) => {
+      this.updateTestSites();
+    });
+  }
+
+  /**
+  * @method onUseLocation
+  *
+  * Listen for the use location button to be clicked.
+  * Update the lat and lon values, trigger input event on the 
+  *     lat and lon element, and close the location widget.
+  */
+  onUseLocation() {
+    $(this.useLocationBtnEl).on('click', (event) => {
+      let selectedSite = this.getSelectedSiteFromClassName(); 
+      let coords = this.getCoordinates(selectedSite);
+      
+      this.lonEl.value = coords[0];
+      this.latEl.value = coords[1];
+      
+      $(this.lonEl).trigger('input');
+      $(this.latEl).trigger('input');
+      
+      $(this.el).modal('hide');
+    });
+  }
+
+  /**
+  * @method plotMap
+  * 
+  * Given a region, plot the corresponding test sites.
+  * When plotData is called the location widget automatically appears.
+  * @param {String} regionId - The region to plot. 
+  */
+  plotMap(regionId) {
+    /* Show location widget */
+    this.show();
+    
+    d3.select(this.useLocationBtnEl)
+        .property('disabled', true);
+
+    /* Replot */
+    this.leafletMap.invalidateSize();
+    /* Plot test sites */
+    let regionGeoJson = this.getRegion(regionId);
+    this.createSiteList(regionGeoJson);
+    this.geoJsonLayer.clearLayers(); 
+    this.geoJsonLayer.addData(regionGeoJson);
+    /* Zoom to region bounds */
+    let regionBounds = L.geoJSON(regionGeoJson.properties.regionBounds)
+        .getBounds();
+    this.leafletMap.fitBounds(regionBounds, this.options.fitBounds);
+    
+    /* Listeners */
+    this.onSiteSelect(); 
+    this.onSiteListSelect();
+    //this.onSnapGrid();
+    this.onUseLocation();
+     
+    /* Replot when container size changes */
+    $(window).resize((event) => {
+      this.leafletMap.invalidateSize();
+      this.leafletMap.fitBounds(regionBounds, this.options.fitBounds);
+    });
+  }
+
+  /**
+  * @method updateTestSites
+  * 
+  * Update the lat and lon of a test site.
+  */
+  updateTestSites() {
+    this.geoJsonLayer.eachLayer((layer) => {
+      let coords = this.getCoordinates(layer.feature);
+      let latlng = L.GeoJSON.coordsToLatLng(coords);
+      layer.setLatLng(latlng);
+    });
+  }
+
+}

--- a/webapp/apps/js/lib/TestSiteView.js
+++ b/webapp/apps/js/lib/TestSiteView.js
@@ -1,0 +1,262 @@
+'use strict';
+
+/**
+* @class TestSiteView
+*
+* @fileoverview Creates a Bootstrap modal overlay to plot test sites.
+*
+* @author Brandon Clayton
+*/
+export default class TestSiteView {
+
+  /**
+  * @param {HTMLElement} latEl - The HTML element associated with the
+  *     latitude input.
+  * @param {HTMLElement} lonEl - The HTML element associated with the
+  *     longitude input.
+  * @param {HTMLElement} activationBtnEl - The HTML element associated with
+  *     a button that onced pressed would show the location widget.
+  */
+  constructor(latEl, lonEl, activationBtnEl) {
+    /** @type {String} */
+    this.webServiceUrl = '/nshmp-haz-ws/util/testsites';
+    
+    /** @type {Object} */
+    this.viewOptions = {
+      mapWidth: '75%',
+      siteListWidth: '25%',
+    };
+    
+    /** @type {HTMLElement} */
+    this.latEl = latEl;
+    /** @type {HTMLElement} */
+    this.lonEl = lonEl;
+    /** @type {HTMLElement} */
+    this.activationBtnEl = activationBtnEl;
+    
+    /* Set btn to disabled until tes sties are loaded */
+    d3.select(this.activationBtnEl)
+        .property('disabled', true);
+
+    /** @type {HTMLElement} */
+    this.el = this.createOverlay();
+    /** @type {HTMLElement} */
+    this.mapBodyEl = this.el.querySelector('#map-body'); 
+    /** @type {HTMLElement} */
+    this.siteListEl = this.el.querySelector('#site-list'); 
+    /** @type {HTMLElement} */
+    this.viewOverlayFooterEl = this.el.querySelector('.modal-footer');
+    /** @type {HTMLElement} */
+    this.snapGridEl = this.el.querySelector('#snap-grid');
+    /** @type {HTMLElement} */
+    this.useLocationBtnEl = this.el.querySelector('#use-location');
+    /** @type {HTMLElement} */
+    //this.regionListEl = this.el.querySelector('#test-site-region-menu');
+  }
+
+  /**
+  * @method createSiteList
+  *
+  * Create the site list in the modal body.
+  * @param {Object} sites -  The feature collection of test sites.
+  */
+  createSiteList(sites) {
+    d3.select(this.siteListEl)
+        .selectAll('label')
+        .remove();
+    
+    d3.select(this.siteListEl)
+        .selectAll('label')
+        .data(sites.features)
+        .enter()
+        .append('label')
+        .attr('class', 'btn btn-sm btn-default')
+        .attr('id', (d, i) => { return d.properties.locationId; })
+        .html((d, i) => {
+          return '<input type="radio" ' +
+              'value="' + d.properties.locationId + '" />' +
+              d.properties.location;
+        });
+  }
+
+  /**
+  * @method createOverlay
+  *
+  * Create the location picker modal. Is hidden until show() method 
+  *     is called.
+  * @return {HTMLElement} The modal element.
+  */
+  createOverlay() {
+    /* Modal */
+    let overlayD3 = d3.select('body')
+        .append('div')
+        .attr('class', 'modal test-site-view')
+        .attr('tabindex', '-1')
+        .attr('role', 'dialog');
+
+    /* Modal content */
+    let contentD3 = overlayD3.append('div')
+        .attr('class', 'modal-dialog modal-lg')
+        .attr('role', 'document')
+        .append('div')
+        .attr('class', 'modal-content');
+    
+    let contentEl = contentD3.node(); 
+    this.createOverlayHeader(contentEl);
+    this.createOverlayBody(contentEl);
+    this.createOverlayFooter(contentEl);
+
+    overlayD3.lower();
+    let el = overlayD3.node();
+    
+    return el;
+  }
+
+  /**
+  * @method createOverlayBody
+  *
+  * Create modal body
+  */
+  createOverlayBody(modalEl) {
+    let bodyD3 = d3.select(modalEl)
+        .append('div')
+        .attr('class', 'modal-body')
+        .append('div')
+        .attr('class', 'row');
+    
+    /* Map body */    
+    bodyD3.append('div')
+        .attr('id', 'map-body')
+        .style('right', this.viewOptions.siteListWidth);
+    
+    /* Site list */
+    bodyD3.append('div')
+        .attr('id', 'site-list-body')
+        .style('left', this.viewOptions.mapWidth)
+        .append('div')
+        .attr('class', 'form-group')
+        .append('div')
+        .attr('class', 'btn-group-vertical')
+        .attr('id', 'site-list')
+        .attr('data-toggle', 'buttons');
+  }
+
+  /**
+  * @method createOverlayFooter
+  *
+  * Create modal footer
+  */
+  createOverlayFooter(modalEl) {
+    /* Modal footer */
+    let footerD3 = d3.select(modalEl)
+        .append('div')
+        .attr('class', 'modal-footer')
+        .style('text-align', 'left');
+ 
+     
+    let formD3 = footerD3.append('div')
+        .attr('class', 'form-inline');
+     
+    /*
+    formD3.append('div')
+        .attr('class', 'pull-left')
+        .append('select')
+        .attr('class', 'form-control')
+        .style('width', 'auto')
+        .attr('id', 'test-site-region-menu');
+    */
+    /* Snap grid checkbox */
+    footerD3.append('label')
+        .attr('class', 'hidden')
+        .style('padding-right', '2em')
+        .html('<input type="checkbox" id="snap-grid"> Snap to 0.1°');
+    
+    /* Use location button */
+    formD3.append('div')
+        .attr('class', 'pull-right')
+        .append('button')
+        .attr('class', 'btn btn-primary')
+        .attr('id', 'use-location')
+        .attr('type', 'button')
+        .text('Use location');
+  }
+
+  /**
+  * @method createOverlayHeader 
+  *
+  * Create modal header
+  */
+  createOverlayHeader(modalEl) {
+    let headerD3 = d3.select(modalEl)
+        .append('div')
+        .attr('class', 'modal-header');
+    
+    headerD3.append('button')
+        .attr('type', 'button')
+        .attr('class', 'close')
+        .attr('data-dismiss', 'modal')
+        .append('span')
+        .attr('aria-hidden', true)
+        .html('&times;');
+
+    headerD3.append('h4')
+        .attr('class', 'modal-title')
+        .text('Test Sites');
+    
+  }
+
+  /*
+  * @method createRegionMenu
+  */
+  createRegionMenu() {
+    d3.select(this.regionListEl)
+        .selectAll('option')
+        .data(this.testSites)
+        .enter()
+        .append('option')
+        .attr('value', (d) => { return d.properties.regionId; })
+        .text((d) => { return d.properties.regionDisplay; })
+  }
+
+  /**
+  * @method getCoordinates
+  *
+  * Get the lat and lon based on if snap grid is checked
+  * @param {Object} data - The test site GeoJson.
+  * @return {Array<Number>} [lon, lat].
+  */
+  getCoordinates(data) {
+    let isSnapChecked = this.snapGridEl.checked;
+    let coords = data.geometry.coordinates;
+    
+    let lon = isSnapChecked ? Math.round(coords[0] * 10.0) / 10.0 :
+        coords[0];
+    
+    let lat = isSnapChecked ? Math.round(coords[1] * 10.0) / 10.0 :
+        coords[1];
+    
+    return [lon, lat];
+  }
+
+  /**
+  * @method getRegion
+  *
+  * Find the region feature collection.
+  * @param {String} regionId - The region to find.
+  */
+  getRegion(regionId) {
+    return this.testSites.find((feature) => {                     
+      return feature.properties.regionId == regionId;                           
+    });
+  }
+  
+  /**
+  * @method show
+  * 
+  * Show the Bootstrap modal and test site plot.
+  */
+  show() {
+    $(this.el).modal({backdrop: 'static'});
+  }
+  
+}

--- a/webapp/apps/js/lib/Tools.js
+++ b/webapp/apps/js/lib/Tools.js
@@ -63,6 +63,9 @@ export default class Tools {
   * Conveince method for calculating percent difference.
   */
   static percentDifference(x0, x1) {
+    if (Number.isNaN(parseFloat(x0)) || 
+        Number.isNaN(parseFloat(x1))) return NaN;
+
     return ((x0 - x1) / ((x0 + x1) / 2)) * 100.0; 
   }
   

--- a/webapp/apps/model-compare.html
+++ b/webapp/apps/model-compare.html
@@ -16,9 +16,10 @@
   <!-- ............. Bootstrap ............ -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
   <!-- ............. Bootstrap ............ -->
-
+  
    
   <!-- ........... CSS Files ....... -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" />
   <link rel="stylesheet" href="css/template.css"      type="text/css">
   <link rel="stylesheet" href="css/D3View.css" type="text/css">
   <link rel="stylesheet" href="css/model-compare.css" type="text/css">
@@ -77,6 +78,14 @@
           </div>
         </div>
         <!-- .................. End: Enter Logitude ................. -->
+        
+        <!-- Choose location on map -->
+        <div class='form-group form-group-sm'>
+          <button class="btn btn-default" id='test-site-picker' type='button'>
+            Choose a test site
+          </button>
+        </div>
+        <!-- End: Choose location on map -->
 
         <!-- .................. IMT Menu ............................ -->
         <div class="form-group form-group-sm">
@@ -118,6 +127,7 @@
 
   <!-- Application Specific JavaScript ......... -->
   <script src="https://d3js.org/d3.v4.min.js"></script>
+  <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script> 
   
   <script type='module'>
     import Config from './js/lib/Config.js';

--- a/webapp/apps/model-explorer.html
+++ b/webapp/apps/model-explorer.html
@@ -19,6 +19,7 @@
 
    
   <!-- ........... CSS Files ....... -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" />
   <link rel="stylesheet" href="css/template.css" type="text/css">
   <link rel="stylesheet" href="css/D3View.css" type="text/css">
   <link rel="stylesheet" href="css/model-explorer.css" type="text/css">
@@ -76,6 +77,14 @@
           </div>
         </div>
         <!-- .................. End: Enter Logitude ................. -->
+        
+        <!-- Choose location on map -->
+        <div class='form-group form-group-sm'>
+          <button class="btn btn-default" id='test-site-picker' type='button'>
+            Choose a test site
+          </button>
+        </div>
+        <!-- End: Choose location on map -->
 
         <!-- .................. IMT Menu ............................ -->
         <div class="form-group form-group-sm">
@@ -117,6 +126,7 @@
 
   <!-- Application Specific JavaScript ......... -->
   <script src="https://d3js.org/d3.v4.min.js"></script>
+  <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
   
   <script type='module'>
     import Config from './js/lib/Config.js';


### PR DESCRIPTION
Created a location widget that allows the user to select a test site from a Leaflet map.

The following sites have the location widget integrated:
* dynamic-compare.html
* geo-deagg.html
* model-comapre.html
* model-explorer.html

The test-sites.html site has been remove from the dashboard and header menu as the site will need updated to the new location widget. 