### PR TITLE
Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.classpath
+.project
+.settings
+.gradle
+bin
+build
+classes
+tmp
+webapp/models
+webapp/jsdocs
+Scratch*.java
+scratch*.html
+Scratch*.js
+webapp/config.json
+.vscode
+config.properties
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 ################################
 # Dockerfile for nshmp-haz-ws
+#
+# Note: Models load as requested. While all supported models are
+# available, requesting them all will eventually result in an
+# OutOfMemoryError. Increase -Xmx to -Xmx16g or -Xmx24g, if available.
 ################################
 
 # Project
@@ -61,7 +65,7 @@ ARG war_path
 COPY --from=builder ${war_path} ${CATALINA_HOME}/webapps/.
 
 # Set Java memory
-ENV JAVA_OPTS -Xms1g -Xmx4g 
+ENV JAVA_OPTS -Xms1g -Xmx8g
 
 # Expose port
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+################################
+# Dockerfile for nshmp-haz-ws
+################################
+
+# Project
+ARG project=nshmp-haz-ws
+
+# Builder image working directory
+ARG builder_workdir=/app/${project}
+
+# Path to WAR file in builder image
+ARG war_path=${builder_workdir}/build/libs/${project}.war
+
+####
+# Builder Image: Java 8
+#   - Install git
+#   - Download repositories (docker.sh)
+#   - Build nshmp-haz-ws
+####
+FROM openjdk:8-alpine as builder
+
+# Get builder workdir
+ARG builder_workdir
+
+# Repository version
+ARG NSHMP_HAZ_VERSION=master
+ARG NSHM_COUS_2018_VERSION=master
+ARG NSHM_COUS_2014_VERSION=master
+ARG NSHM_COUS_2008_VERSION=master
+ARG NSHM_AK_2007_VERSION=master
+
+# Set working directory
+WORKDIR ${builder_workdir} 
+
+# Copy project over to container
+COPY . ${builder_workdir}/. 
+
+# Install curl, git, bash
+RUN apk add --no-cache git curl bash
+
+# Download repositories
+RUN cd .. && bash ${builder_workdir}/docker.sh
+
+# Build nshmp-haz-ws
+RUN ./gradlew assemble
+
+####
+# Application Image: Tomcat
+#   - Copy WAR file from builder image
+#   - Run Tomcat
+####
+FROM tomcat:8-alpine
+
+# Set author
+LABEL maintainer="Peter Powers <pmpowers@usgs.gov>"
+
+# Get WAR path
+ARG war_path
+
+# Copy WAR file from builder image
+COPY --from=builder ${war_path} ${CATALINA_HOME}/webapps/.
+
+# Set Java memory
+ENV JAVA_OPTS -Xms1g -Xmx4g 
+
+# Run Tomcat
+ENTRYPOINT ${CATALINA_HOME}/bin/catalina.sh run

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,5 +63,8 @@ COPY --from=builder ${war_path} ${CATALINA_HOME}/webapps/.
 # Set Java memory
 ENV JAVA_OPTS -Xms1g -Xmx4g 
 
+# Expose port
+EXPOSE 8080
+
 # Run Tomcat
 ENTRYPOINT ${CATALINA_HOME}/bin/catalina.sh run

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 
 services:
-  nshmp-haz-ws:
+  webapp:
     # nshmp-haz-ws image
     image: nshmp/nshmp-haz-ws:latest
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 
 services:
-  webapp:
+  nshmp-haz-ws:
     # nshmp-haz-ws image
     image: nshmp/nshmp-haz-ws:latest
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: "3"
+
+services:
+  nshmp-haz-ws:
+    # nshmp-haz-ws image
+    image: nshmp/nshmp-haz-ws:latest
+
+    # Build this directory
+    build: .
+
+    # Restart always
+    restart: always
+
+    # Set to port 8080
+    ports:
+      - 8080:8080
+
+    # Look for changes to WAR file
+    volumes:
+      - ./build/libs/nshmp-haz-ws.war:/usr/local/tomcat/webapps/nshmp-haz-ws.war

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+####
+# Download a USGS repository from Github.
+# Arguments:
+#   (string) repo - The project to download
+#   (string) version - The version to download
+# Returns:
+#   None
+####
+download_repo() {
+  local repo=${1}
+  local version=${2}
+  local url="https://github.com/usgs/${repo}/archive/${version}.tar.gz"
+
+  printf "\n Downloading [${url}] \n"
+  curl -L ${url} | tar -xz
+  mv ${repo}-${version#v*} ${repo}
+}
+
+# Download nshmp-haz
+download_repo "nshmp-haz" ${NSHMP_HAZ_VERSION}
+
+# Download nshm-ak-2007
+download_repo "nshm-ak-2007" ${NSHM_AK_2007_VERSION}
+
+# Download nshm-cous-2008
+download_repo "nshm-cous-2008" ${NSHM_COUS_2008_VERSION}
+
+# Download nshm-cous-2014
+download_repo "nshm-cous-2014" ${NSHM_COUS_2014_VERSION}
+
+# Download nshm-cous-2018
+download_repo "nshm-cous-2018" ${NSHM_COUS_2018_VERSION}


### PR DESCRIPTION

## nshmp-haz-ws is Dockerized
* New Dockerfile
* New .dockerignore file
* New docker.sh file for Docker to download repos
* New docker-compose.yaml file

The following information will be added to the wiki when this get approved.

### Run nshmp-haz-ws using Docker
```bash
docker run -p 8080:8080 -d nshmp/nshmp-haz-ws:latest
```

### Build and Run local image
```bash
# Build
docker build -t nshmp-haz-ws:latest .

# Run
docker run -p 8080:8080 -d nshmp-haz-ws:latest
```

### Docker build arguments
Docker image can be build with version, commit, or branch of the repositories it needs.
```bash
docker build \
--build-arg NSHMP_HAZ_VERSION=master \
--build-arg NSHM_AK_2007_VERSION=master \
--build-arg NSHM_COUS_2008_VERSION=master \
--build-arg NSHM_COUS_2014_VERSION=master \
--build-arg NSHM_COUS_2018_VERSION=master \
-t nshmp-haz-ws:latest .
```