### PR TITLE
Upload results to S3

### DIFF
--- a/src/gov/usgs/earthquake/nshmp/aws/HazardResultSliceLambda.java
+++ b/src/gov/usgs/earthquake/nshmp/aws/HazardResultSliceLambda.java
@@ -242,8 +242,7 @@ public class HazardResultSliceLambda implements RequestStreamHandler {
         request.bucket,
         request.key + "/" + MAP_FILE,
         input,
-        metadata)
-            .withCannedAcl(CannedAccessControlList.PublicRead);
+        metadata);
     S3.putObject(putRequest);
     input.close();
   }

--- a/src/gov/usgs/earthquake/nshmp/aws/HazardResultsMetadataLambda.java
+++ b/src/gov/usgs/earthquake/nshmp/aws/HazardResultsMetadataLambda.java
@@ -24,7 +24,6 @@ import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.google.common.base.Enums;
-import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
 
 import gov.usgs.earthquake.nshmp.aws.Util.LambdaHelper;
@@ -51,14 +50,13 @@ public class HazardResultsMetadataLambda implements RequestStreamHandler {
   private static final AmazonS3 S3 = AmazonS3ClientBuilder.defaultClient();
   private static final String RESULT_BUCKET = "nshmp-haz-lambda";
   private static final String RESULT_KEY = "nshmp-haz-aws-results-metadata.json";
-  
+
   @Override
   public void handleRequest(
       InputStream input,
       OutputStream output,
       Context context) throws IOException {
     LambdaHelper lambdaHelper = new LambdaHelper(input, output, context);
-    lambda = lambdaHelper;
 
     try {
       Response response = processRequest();
@@ -72,7 +70,7 @@ public class HazardResultsMetadataLambda implements RequestStreamHandler {
       output.write(message.getBytes());
     }
   }
-  
+
   private static Response processRequest() {
     Set<String> users = getUsers();
     List<HazardResults> hazardResults = listObjects();
@@ -188,7 +186,7 @@ public class HazardResultsMetadataLambda implements RequestStreamHandler {
   private static void uploadResults(String results) {
     byte[] bytes = results.getBytes();
     ByteArrayInputStream input = new ByteArrayInputStream(bytes);
-    ObjectMetadata metadata =  new ObjectMetadata();
+    ObjectMetadata metadata = new ObjectMetadata();
     metadata.setContentLength(bytes.length);
     metadata.setContentType("application/json");
 
@@ -197,8 +195,8 @@ public class HazardResultsMetadataLambda implements RequestStreamHandler {
         RESULT_KEY,
         input,
         metadata)
-        .withCannedAcl(CannedAccessControlList.PublicRead);
-    
+       .withCannedAcl(CannedAccessControlList.PublicRead);
+
     S3.putObject(request);
   }
 

--- a/src/gov/usgs/earthquake/nshmp/aws/HazardResultsMetadataLambda.java
+++ b/src/gov/usgs/earthquake/nshmp/aws/HazardResultsMetadataLambda.java
@@ -100,16 +100,16 @@ public class HazardResultsMetadataLambda implements RequestStreamHandler {
 
   private static List<HazardResults> transformS3Listing(List<S3Listing> s3Listings) {
     List<HazardResults> hazardResults = new ArrayList<>();
-    TreeSet<String> resultDirectories = s3Listings.stream()
+    TreeSet<String> resultDirectories = s3Listings.parallelStream()
         .map(listing -> listing.resultPrefix)
         .collect(Collectors.toCollection(TreeSet::new));
 
     resultDirectories.forEach(resultPrefix -> {
-      List<S3Listing> s3Filteredlistings = s3Listings.stream()
+      List<S3Listing> s3Filteredlistings = s3Listings.parallelStream()
           .filter(listing -> listing.resultPrefix.equals(resultPrefix))
           .collect(Collectors.toList());
 
-      List<HazardListing> listings = s3Filteredlistings.stream()
+      List<HazardListing> listings = s3Filteredlistings.parallelStream()
           .map(listing -> s3ListingToHazardListing(listing))
           .collect(Collectors.toList());
 

--- a/src/gov/usgs/earthquake/nshmp/aws/HazardResultsMetadataLambda.java
+++ b/src/gov/usgs/earthquake/nshmp/aws/HazardResultsMetadataLambda.java
@@ -3,6 +3,7 @@ package gov.usgs.earthquake.nshmp.aws;
 import static gov.usgs.earthquake.nshmp.aws.HazardResultSliceLambda.MAP_FILE;
 import static gov.usgs.earthquake.nshmp.www.ServletUtil.GSON;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -17,9 +18,13 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.google.common.base.Enums;
+import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
 
 import gov.usgs.earthquake.nshmp.aws.Util.LambdaHelper;
@@ -44,18 +49,21 @@ public class HazardResultsMetadataLambda implements RequestStreamHandler {
   private static final int IMT_DIR_BACK_FROM_SOURCE = 4;
   private static final String S3_BUCKET = "nshmp-hazout";
   private static final AmazonS3 S3 = AmazonS3ClientBuilder.defaultClient();
-
+  private static final String RESULT_BUCKET = "nshmp-haz-lambda";
+  private static final String RESULT_KEY = "nshmp-haz-aws-results-metadata.json";
+  
   @Override
   public void handleRequest(
       InputStream input,
       OutputStream output,
       Context context) throws IOException {
     LambdaHelper lambdaHelper = new LambdaHelper(input, output, context);
+    lambda = lambdaHelper;
 
     try {
       Response response = processRequest();
       String json = GSON.toJson(response, Response.class);
-      lambdaHelper.logger.log("Response: " + json + "\n");
+      uploadResults(json);
       output.write(json.getBytes());
       output.close();
     } catch (Exception e) {
@@ -64,11 +72,10 @@ public class HazardResultsMetadataLambda implements RequestStreamHandler {
       output.write(message.getBytes());
     }
   }
-
+  
   private static Response processRequest() {
     Set<String> users = getUsers();
     List<HazardResults> hazardResults = listObjects();
-
     Result result = new Result(users, hazardResults);
     return new Response(result);
   }
@@ -176,6 +183,23 @@ public class HazardResultsMetadataLambda implements RequestStreamHandler {
     }
 
     return dataType;
+  }
+
+  private static void uploadResults(String results) {
+    byte[] bytes = results.getBytes();
+    ByteArrayInputStream input = new ByteArrayInputStream(bytes);
+    ObjectMetadata metadata =  new ObjectMetadata();
+    metadata.setContentLength(bytes.length);
+    metadata.setContentType("application/json");
+
+    PutObjectRequest request = new PutObjectRequest(
+        RESULT_BUCKET,
+        RESULT_KEY,
+        input,
+        metadata)
+        .withCannedAcl(CannedAccessControlList.PublicRead);
+    
+    S3.putObject(request);
   }
 
   static class HazardDataType<E extends Enum<E>> {

--- a/src/gov/usgs/earthquake/nshmp/aws/HazardResultsMetadataLambda.java
+++ b/src/gov/usgs/earthquake/nshmp/aws/HazardResultsMetadataLambda.java
@@ -194,8 +194,7 @@ public class HazardResultsMetadataLambda implements RequestStreamHandler {
         RESULT_BUCKET,
         RESULT_KEY,
         input,
-        metadata)
-       .withCannedAcl(CannedAccessControlList.PublicRead);
+        metadata);
 
     S3.putObject(request);
   }

--- a/src/gov/usgs/earthquake/nshmp/aws/HazardResultsSlicerLambda.java
+++ b/src/gov/usgs/earthquake/nshmp/aws/HazardResultsSlicerLambda.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.services.lambda.AWSLambda;
 import com.amazonaws.services.lambda.AWSLambdaClientBuilder;
 import com.amazonaws.services.lambda.model.InvokeRequest;
@@ -43,8 +44,20 @@ public class HazardResultsSlicerLambda implements RequestStreamHandler {
   static final String CURVES_FILE = "curves.csv";
 
   private static final String LAMBDA_CALL = "nshmp-haz-result-slice";
+  private static final String ZIP_LAMBDA_CALL = "nshmp-haz-zip-results";
   private static final AmazonS3 S3 = AmazonS3ClientBuilder.defaultClient();
-  private static final AWSLambda LAMBDA_CLIENT = AWSLambdaClientBuilder.defaultClient();
+  private static AWSLambda LAMBDA_CLIENT;
+
+  private static final int SDK_TIMEOUT = 10 * 60 * 1000;
+
+  static {
+    ClientConfiguration config = new ClientConfiguration()
+        .withSocketTimeout(SDK_TIMEOUT);
+
+    LAMBDA_CLIENT = AWSLambdaClientBuilder.standard()
+        .withClientConfiguration(config)
+        .build();
+  }
 
   @Override
   public void handleRequest(
@@ -89,6 +102,7 @@ public class HazardResultsSlicerLambda implements RequestStreamHandler {
         });
 
     futures.forEach(CompletableFuture::join);
+    zipResults(request);
     return new Response(request);
   }
 
@@ -98,18 +112,7 @@ public class HazardResultsSlicerLambda implements RequestStreamHandler {
       String curvesPath) throws IOException {
     return readCurveFile(request, curvesPath)
         .thenAcceptAsync(result -> {
-          try {
-            Object object = GSON.fromJson(
-                new String(result.getPayload().array(), "UTF-8"),
-                Object.class);
-            JsonObject json = GSON.toJsonTree(object).getAsJsonObject();
-            String status = json.get("status").getAsString();
-            if (Status.ERROR.toString().equals(status)) {
-              throw new RuntimeException(json.get("message").getAsString());
-            }
-          } catch (Exception e) {
-            throw new RuntimeException(e);
-          }
+          checkLambdaResponse(result);
         });
   }
 
@@ -154,6 +157,26 @@ public class HazardResultsSlicerLambda implements RequestStreamHandler {
   private static void checkBucket(RequestData request) {
     if (!S3.doesBucketExistV2(request.bucket)) {
       throw new RuntimeException(String.format("S3 bucket [%s] does not exist", request.bucket));
+    }
+  }
+
+  private static void zipResults(RequestData request) {
+    InvokeRequest invokeRequest = new InvokeRequest()
+        .withFunctionName(ZIP_LAMBDA_CALL)
+        .withPayload(GSON.toJson(request));
+
+    InvokeResult result = LAMBDA_CLIENT.invoke(invokeRequest);
+    checkLambdaResponse(result);
+  }
+
+  private static void checkLambdaResponse(InvokeResult result) {
+    Object object = GSON.fromJson(
+        new String(result.getPayload().array()),
+        Object.class);
+    JsonObject json = GSON.toJsonTree(object).getAsJsonObject();
+    String status = json.get("status").getAsString();
+    if (Status.ERROR.toString().equals(status)) {
+      throw new RuntimeException(json.get("message").getAsString());
     }
   }
 

--- a/src/gov/usgs/earthquake/nshmp/aws/HazardResultsSlicerLambda.java
+++ b/src/gov/usgs/earthquake/nshmp/aws/HazardResultsSlicerLambda.java
@@ -108,7 +108,7 @@ public class HazardResultsSlicerLambda implements RequestStreamHandler {
               throw new RuntimeException(json.get("message").getAsString());
             }
           } catch (Exception e) {
-            lambdaHelper.logger.log(Throwables.getStackTraceAsString(e));
+            throw new RuntimeException(e);
           }
         });
   }


### PR DESCRIPTION
The `HazardResultsMetadataLambda` function takes too long to wait for json response.
The json response in now uploaded to aws S3 `nshmp-haz-lambda` bucket with file
name `nshmp-haz-aws-results-metadata.json`

This Lambda function is called when jobs are running in the cloud to update this file.

