### PR TITLE
adjusted busy flag; added reset

### DIFF
--- a/src/gov/usgs/earthquake/nshmp/www/DeaggService.java
+++ b/src/gov/usgs/earthquake/nshmp/www/DeaggService.java
@@ -68,7 +68,6 @@ public final class DeaggService extends NshmpServlet {
           urlHelper.url,
           ServletUtil.hitCount,
           ServletUtil.missCount);
-      //response.setStatus(503);
       response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
       response.getWriter().print(message);
       return;
@@ -95,14 +94,15 @@ public final class DeaggService extends NshmpServlet {
       Result result = ServletUtil.TASK_EXECUTOR.submit(task).get();
       String resultStr = GSON.toJson(result);
       response.getWriter().print(resultStr);
+      ServletUtil.uhtBusy = false;
 
     } catch (Exception e) {
       String message = Metadata.errorMessage(urlHelper.url, e, false);
       response.getWriter().print(message);
+      ServletUtil.uhtBusy = false;
       getServletContext().log(urlHelper.url, e);
     }
     ServletUtil.hitCount++;
-    ServletUtil.uhtBusy = false;
   }
 
   private static class DeaggTask extends TimedTask<Result> {

--- a/src/gov/usgs/earthquake/nshmp/www/HazardService.java
+++ b/src/gov/usgs/earthquake/nshmp/www/HazardService.java
@@ -127,6 +127,13 @@ public final class HazardService extends NshmpServlet {
       urlHelper.writeResponse(Metadata.HAZARD_USAGE);
       return;
     }
+    
+    if (pathInfo.equals("/reset")) {
+      ServletUtil.uhtBusy = false;
+      response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
+      response.getWriter().print("busy = false");
+      return;
+    }
 
     if (ServletUtil.uhtBusy) {
       ServletUtil.missCount++;
@@ -134,7 +141,6 @@ public final class HazardService extends NshmpServlet {
           urlHelper.url,
           ServletUtil.hitCount,
           ServletUtil.missCount);
-      //response.setStatus(503);
       response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
       response.getWriter().print(message);
       return;
@@ -162,14 +168,15 @@ public final class HazardService extends NshmpServlet {
       // GSON.toJson(result, response.getWriter()); TODO test and use elsewhere?
       String resultStr = GSON.toJson(result);
       response.getWriter().print(resultStr);
+      ServletUtil.uhtBusy = false;
 
     } catch (Exception e) {
       String message = Metadata.errorMessage(urlHelper.url, e, false);
       response.getWriter().print(message);
+      ServletUtil.uhtBusy = false;
       getServletContext().log(urlHelper.url, e);
     }
     ServletUtil.hitCount++;
-    ServletUtil.uhtBusy = false;
   }
 
   /*

--- a/src/gov/usgs/earthquake/nshmp/www/RateService.java
+++ b/src/gov/usgs/earthquake/nshmp/www/RateService.java
@@ -111,7 +111,6 @@ public final class RateService extends NshmpServlet {
           urlHelper.url,
           ServletUtil.hitCount,
           ServletUtil.missCount);
-      //response.setStatus(503);
       response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
       response.getWriter().print(message);
       return;
@@ -142,14 +141,15 @@ public final class RateService extends NshmpServlet {
           .build();
       String resultStr = GSON.toJson(result);
       response.getWriter().print(resultStr);
+      ServletUtil.uhtBusy = false;
 
     } catch (Exception e) {
       String message = Metadata.errorMessage(urlHelper.url, e, false);
       response.getWriter().print(message);
+      ServletUtil.uhtBusy = false;
       getServletContext().log(urlHelper.url, e);
     }
     ServletUtil.hitCount++;
-    ServletUtil.uhtBusy = false;
   }
 
   /* Reduce query string key-value pairs */


### PR DESCRIPTION
Some combination of closely spaced requests is leaving the flag `busy =true` from which it will never accept another request. Testing adjustments and also adding ability to reset flag